### PR TITLE
Fix missing -fpic to link properly with Qt 5.15.0

### DIFF
--- a/patch/crypto/CMakeLists.txt
+++ b/patch/crypto/CMakeLists.txt
@@ -280,6 +280,10 @@ endif()
 
 add_library( crypto ${LIBSRC} ${OBJECTS_SRC} )
 
+if( NOT MSVC )
+    target_compile_options(crypto PRIVATE -fPIC)
+endif()
+
 target_include_directories( crypto PUBLIC ${PROJECT_BINARY_DIR}/include )
 
 if( WIN32 AND NOT CYGWIN )

--- a/patch/ssl/CMakeLists.txt
+++ b/patch/ssl/CMakeLists.txt
@@ -43,11 +43,11 @@ include_directories( BEFORE SYSTEM
   ${PROJECT_SOURCE_DIR}/ # e_os.h
 )
 
+add_library( ssl ${LIBSRC} )
+
 if( NOT MSVC )
     target_compile_options(ssl PRIVATE -fPIC)
 endif()
-
-add_library( ssl ${LIBSRC} )
 
 target_include_directories( ssl PUBLIC ${PROJECT_BINARY_DIR}/include )
 

--- a/patch/ssl/CMakeLists.txt
+++ b/patch/ssl/CMakeLists.txt
@@ -43,6 +43,10 @@ include_directories( BEFORE SYSTEM
   ${PROJECT_SOURCE_DIR}/ # e_os.h
 )
 
+if( NOT MSVC )
+    target_compile_options(ssl PRIVATE -fPIC)
+endif()
+
 add_library( ssl ${LIBSRC} )
 
 target_include_directories( ssl PUBLIC ${PROJECT_BINARY_DIR}/include )


### PR DESCRIPTION
See my report https://github.com/flagarde/openssl-cmake/issues/1